### PR TITLE
Add Pro-Nodes75 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,24 @@ An Awesome List of Celestia Resources
 * [Telegram](https://t.me/CelestiaBrazil)
 
 ## Node operator contributions
+
+#### [Pro-Nodes75](https://node75.org/)
+##### Tools
+Celestia Cluster [monitoring tool](https://github.com/the-node75/mon_celestia)
+Celestia IBC [information matrix](https://services.node75.org/ibc-matrix/celestia)
+
+##### Mainnet
+###### Endpoints
+- RPC:  https://rpc.celestia.node75.org
+- API:  https://api.celestia.node75.org
+- GRPC: `grpc.celestia.node75.org:9220`
+  
+###### Bootstrap node
+- Peer: `ce99d7da2530f75d05880d13d9eda384d5a1afe4@peer.celestia.node75.org:23356`
+- Seed: `86bd5cb6e762f673f1706e5889e039d5406b4b90@seed.celestia.node75.org:20356`
+
+##### Testnet
+###### Bootstrap node
+- Peer: `27971306bc55695fa7ca38b14df9181043aab5a1@peer.celestia.testnet.node75.org:26656`
+- Seed: `86bd5cb6e762f673f1706e5889e039d5406b4b90@seed.celestia.testnet.node75.org:37116`
+

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ An Awesome List of Celestia Resources
 
 ## Node operator contributions
 
-#### [Pro-Nodes75](https://node75.org/)
+#### [Pro-Nodes75](https://services.node75.org/chains/celestia-mainnet)
 ##### Tools
 * Celestia Cluster [monitoring tool](https://github.com/the-node75/mon_celestia)
 * Celestia IBC [information matrix](https://services.node75.org/ibc-matrix/celestia)
@@ -118,6 +118,10 @@ An Awesome List of Celestia Resources
 ###### Bootstrap node
 - Peer: `ce99d7da2530f75d05880d13d9eda384d5a1afe4@peer.celestia.node75.org:23356`
 - Seed: `86bd5cb6e762f673f1706e5889e039d5406b4b90@seed.celestia.node75.org:20356`
+
+###### Ecosystem
+
+* Kyve' [Celestia Data pools](https://app.kyve.network/#/pools/9/validators)
 
 ##### Testnet
 ###### Bootstrap node

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ An Awesome List of Celestia Resources
 
 ## Node operator contributions
 
+### IBC
+**[General IBC table](https://relayers.smartstake.io/network/TIA)** of Celestia Relayers from [SmartStake.io](https://smartstake.io/)
+
+
 #### [Pro-Nodes75](https://services.node75.org/chains/celestia-mainnet)
 ##### Tools
 * Celestia Cluster [monitoring tool](https://github.com/the-node75/mon_celestia)

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ An Awesome List of Celestia Resources
 
 #### [Pro-Nodes75](https://node75.org/)
 ##### Tools
-Celestia Cluster [monitoring tool](https://github.com/the-node75/mon_celestia)
-Celestia IBC [information matrix](https://services.node75.org/ibc-matrix/celestia)
+* Celestia Cluster [monitoring tool](https://github.com/the-node75/mon_celestia)
+* Celestia IBC [information matrix](https://services.node75.org/ibc-matrix/celestia)
 
 ##### Mainnet
 ###### Endpoints


### PR DESCRIPTION
## Overview
added:
1) link to the smartstake.io TIA' IBC-relayers dashboard
2) Pro-Node75' tools/ endpoints/ Bootstrap nodes

not added:
our past personal contribution without any community useful content (twitter links/ community help/ bridge ID's an so)


